### PR TITLE
feat: remove members table pagination

### DIFF
--- a/src/pages/About/RequestsGrid.tsx
+++ b/src/pages/About/RequestsGrid.tsx
@@ -249,7 +249,6 @@ export const RequestsGrid = ({ lcStatus }: LcStatusType) => {
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
@@ -315,26 +314,6 @@ export const RequestsGrid = ({ lcStatus }: LcStatusType) => {
             </TableBody>
           </Table>
         )}
-      </div>
-      <div className="flex items-center justify-end space-x-2 py-4">
-        <div className="space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            Previous
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            Next
-          </Button>
-        </div>
       </div>
       <MemberInfo
         lcStatus={lcStatus}

--- a/src/pages/About/RequestsGrid.tsx
+++ b/src/pages/About/RequestsGrid.tsx
@@ -9,7 +9,6 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
-  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'


### PR DESCRIPTION
I personally find it quite annoying scrolling all the way to the button and clicking next, to just browse who is in the fellowship. 

As we are fetching the data completely anyways, it does not make a difference loading wise.