### PR TITLE
feat: useFellowshipMembers hook with react-query

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
+    "plugin:@tanstack/eslint-plugin-query/recommended"
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
+    "@tanstack/query-sync-storage-persister": "^5.53.1",
     "@tanstack/react-query": "^5.52.3",
+    "@tanstack/react-query-persist-client": "^5.53.1",
     "@tanstack/react-table": "^8.20.5",
     "buffer": "^6.0.3",
     "class-variance-authority": "^0.7.0",
@@ -53,6 +55,7 @@
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.53.0",
+    "@tanstack/react-query-devtools": "^5.53.1",
     "@types/node": "^22.5.1",
     "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
+    "@tanstack/react-query": "^5.52.3",
     "@tanstack/react-table": "^8.20.5",
     "buffer": "^6.0.3",
     "class-variance-authority": "^0.7.0",
@@ -51,6 +52,7 @@
     "vaul": "^0.9.1"
   },
   "devDependencies": {
+    "@tanstack/eslint-plugin-query": "^5.53.0",
     "@types/node": "^22.5.1",
     "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,15 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/query-sync-storage-persister':
+        specifier: ^5.53.1
+        version: 5.53.1
       '@tanstack/react-query':
         specifier: ^5.52.3
         version: 5.52.3(react@18.3.1)
+      '@tanstack/react-query-persist-client':
+        specifier: ^5.53.1
+        version: 5.53.1(@tanstack/react-query@5.52.3(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.20.5
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -111,6 +117,9 @@ importers:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.53.0
         version: 5.53.0(eslint@8.57.0)(typescript@5.5.4)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.53.1
+        version: 5.53.1(@tanstack/react-query@5.52.3(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^22.5.1
         version: 22.5.1
@@ -1434,6 +1443,30 @@ packages:
 
   '@tanstack/query-core@5.52.3':
     resolution: {integrity: sha512-+Gh7lXn+eoAsarvvnndgqBeJ5lOjup8qgQnrTsFuhNTEAo0H934DxEPro4s3TlmvITfDTJ3UDCy7kY8Azm0qsA==}
+
+  '@tanstack/query-core@5.53.1':
+    resolution: {integrity: sha512-mvLG7s4Zy3Yvc2LsKm8BVafbmPrsReKgqwhmp4XKVmRW9us3KbWRqu3qBBfhVavcUUEHfNK7PvpTchvQpVdFpw==}
+
+  '@tanstack/query-devtools@5.52.3':
+    resolution: {integrity: sha512-oGX9qJuNpr4vOQyeksqHr+FgLQGs5UooK87R1wTtcsUUdrRKGSgs3cBllZMtWBJxg+yVvg0TlHNGYLMjvqX3GA==}
+
+  '@tanstack/query-persist-client-core@5.53.1':
+    resolution: {integrity: sha512-2cR3sfziXWRKNdX7GUimA+pF3wF1aY+Z0PzOL6426bpx/b5V/eSEw+JWmRSFeY/s6J6flqnqenKlL+pRPpGTog==}
+
+  '@tanstack/query-sync-storage-persister@5.53.1':
+    resolution: {integrity: sha512-8jUf9iBDFV/pFobL13wYkFglAefZ9oxk5WXfemABbCHKSJ4l8uY7R/nrNN91ncHgegNdALqG5n8QcoI77BvOgw==}
+
+  '@tanstack/react-query-devtools@5.53.1':
+    resolution: {integrity: sha512-AjShRLM3/9Rglgeo0X52M8MKPEvcNnFQvs3yZq8ExQWu8YhZMzqVsFVn4PqOeyEHbnsRS2bmi0jPP/tBrlWU0A==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.53.1
+      react: ^18 || ^19
+
+  '@tanstack/react-query-persist-client@5.53.1':
+    resolution: {integrity: sha512-2ntl2ZcU5MqQmf7LCIpfSk0se/Nh49Zfk+qVcxJ3ILZKUtOamJBewHNbcI58o9GfUYUg7k9GOQsDT2gZdPFKQA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.53.1
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.52.3':
     resolution: {integrity: sha512-1K7l2hkqlWuh5SdaTYPSwMmHJF5dDk5INK+EtiEwUZW4+usWTXZx7QeHuk078oSzTzaVkEFyT3VquK7F0hYkUw==}
@@ -4331,6 +4364,31 @@ snapshots:
       - typescript
 
   '@tanstack/query-core@5.52.3': {}
+
+  '@tanstack/query-core@5.53.1': {}
+
+  '@tanstack/query-devtools@5.52.3': {}
+
+  '@tanstack/query-persist-client-core@5.53.1':
+    dependencies:
+      '@tanstack/query-core': 5.53.1
+
+  '@tanstack/query-sync-storage-persister@5.53.1':
+    dependencies:
+      '@tanstack/query-core': 5.53.1
+      '@tanstack/query-persist-client-core': 5.53.1
+
+  '@tanstack/react-query-devtools@5.53.1(@tanstack/react-query@5.52.3(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.52.3
+      '@tanstack/react-query': 5.52.3(react@18.3.1)
+      react: 18.3.1
+
+  '@tanstack/react-query-persist-client@5.53.1(@tanstack/react-query@5.52.3(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-persist-client-core': 5.53.1
+      '@tanstack/react-query': 5.52.3(react@18.3.1)
+      react: 18.3.1
 
   '@tanstack/react-query@5.52.3(react@18.3.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.52.3
+        version: 5.52.3(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.20.5
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -105,6 +108,9 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1(@types/react-dom@18.3.0)(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.53.0
+        version: 5.53.0(eslint@8.57.0)(typescript@5.5.4)
       '@types/node':
         specifier: ^22.5.1
         version: 22.5.1
@@ -1421,6 +1427,19 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
 
+  '@tanstack/eslint-plugin-query@5.53.0':
+    resolution: {integrity: sha512-Q3WgvK2YTGc3h5EaktDouRkKBPGl3QQFLPZBagpBa6zD70PiNoDY72wWrX9T4yKClMmSulAa0wg5Nj3LVXGkEw==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
+  '@tanstack/query-core@5.52.3':
+    resolution: {integrity: sha512-+Gh7lXn+eoAsarvvnndgqBeJ5lOjup8qgQnrTsFuhNTEAo0H934DxEPro4s3TlmvITfDTJ3UDCy7kY8Azm0qsA==}
+
+  '@tanstack/react-query@5.52.3':
+    resolution: {integrity: sha512-1K7l2hkqlWuh5SdaTYPSwMmHJF5dDk5INK+EtiEwUZW4+usWTXZx7QeHuk078oSzTzaVkEFyT3VquK7F0hYkUw==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@tanstack/react-table@8.20.5':
     resolution: {integrity: sha512-WEHopKw3znbUZ61s9i0+i9g8drmDo6asTWbrQh8Us63DAk/M0FkmIqERew6P71HI75ksZ2Pxyuf4vvKh9rAkiA==}
     engines: {node: '>=12'}
@@ -1499,6 +1518,10 @@ packages:
     resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
+  '@typescript-eslint/scope-manager@8.3.0':
+    resolution: {integrity: sha512-mz2X8WcN2nVu5Hodku+IR8GgCOl4C0G/Z1ruaWN4dgec64kDBabuXyPAr+/RgJtumv8EEkqIzf3X2U5DUKB2eg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/type-utils@7.18.0':
     resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -1513,9 +1536,22 @@ packages:
     resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
+  '@typescript-eslint/types@8.3.0':
+    resolution: {integrity: sha512-y6sSEeK+facMaAyixM36dQ5NVXTnKWunfD1Ft4xraYqxP0lC0POJmIaL/mw72CUMqjY9qfyVfXafMeaUj0noWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@7.18.0':
     resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
     engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/typescript-estree@8.3.0':
+    resolution: {integrity: sha512-Mq7FTHl0R36EmWlCJWojIC1qn/ZWo2YiWYc1XVtasJ7FIgjo0MVv9rZWXEE7IK2CGrtwe1dVOxWwqXUdNgfRCA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -1528,9 +1564,19 @@ packages:
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@8.3.0':
+    resolution: {integrity: sha512-F77WwqxIi/qGkIGOGXNBLV7nykwfjLsdauRB/DOFPdv6LTF3BHHkBpq81/b5iMPSF055oO2BiivDJV4ChvNtXA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
   '@typescript-eslint/visitor-keys@7.18.0':
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.3.0':
+    resolution: {integrity: sha512-RmZwrTbQ9QveF15m/Cl28n0LXD6ea2CjkhH5rQ55ewz3H24w+AMCJHPVYaZ8/0HoG8Z3cLLFFycRXxeO2tz9FA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -4276,6 +4322,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tanstack/eslint-plugin-query@5.53.0(eslint@8.57.0)(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/utils': 8.3.0(eslint@8.57.0)(typescript@5.5.4)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@tanstack/query-core@5.52.3': {}
+
+  '@tanstack/react-query@5.52.3(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.52.3
+      react: 18.3.1
+
   '@tanstack/react-table@8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/table-core': 8.20.5
@@ -4377,6 +4438,11 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
 
+  '@typescript-eslint/scope-manager@8.3.0':
+    dependencies:
+      '@typescript-eslint/types': 8.3.0
+      '@typescript-eslint/visitor-keys': 8.3.0
+
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
@@ -4391,12 +4457,29 @@ snapshots:
 
   '@typescript-eslint/types@7.18.0': {}
 
+  '@typescript-eslint/types@8.3.0': {}
+
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.3.6
       globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@5.5.4)
+    optionalDependencies:
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.3.0(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/types': 8.3.0
+      '@typescript-eslint/visitor-keys': 8.3.0
+      debug: 4.3.6
+      fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
@@ -4417,9 +4500,25 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@8.3.0(eslint@8.57.0)(typescript@5.5.4)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.3.0
+      '@typescript-eslint/types': 8.3.0
+      '@typescript-eslint/typescript-estree': 8.3.0(typescript@5.5.4)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/visitor-keys@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.3.0':
+    dependencies:
+      '@typescript-eslint/types': 8.3.0
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'
-import { HashRouter } from 'react-router-dom'
 import { createRoot } from 'react-dom/client'
+import { HashRouter } from 'react-router-dom'
 import App from './App.tsx'
 
 import './index.css'
+
+const queryClient = new QueryClient()
 
 const rootElement = document.getElementById('root')
 if (!rootElement) throw new Error('Failed to find the root element')
@@ -11,8 +14,10 @@ const root = createRoot(rootElement)
 
 root.render(
   <StrictMode>
-    <HashRouter>
-      <App />
-    </HashRouter>
+    <QueryClientProvider client={queryClient}>
+      <HashRouter>
+        <App />
+      </HashRouter>
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,18 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router-dom'
 import App from './App.tsx'
-
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
+import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import './index.css'
 
 const queryClient = new QueryClient()
+
+const persister = createSyncStoragePersister({
+  storage: window.localStorage,
+})
 
 const rootElement = document.getElementById('root')
 if (!rootElement) throw new Error('Failed to find the root element')
@@ -14,10 +20,16 @@ const root = createRoot(rootElement)
 
 root.render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
+    <PersistQueryClientProvider
+      client={queryClient}
+      persistOptions={{ persister }}
+    >
       <HashRouter>
         <App />
       </HashRouter>
-    </QueryClientProvider>
+      {import.meta.env.MODE === 'development' && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
+    </PersistQueryClientProvider>
   </StrictMode>,
 )

--- a/src/pages/About/MemberInfo.tsx
+++ b/src/pages/About/MemberInfo.tsx
@@ -3,7 +3,6 @@ import { AccountName } from './AccountName'
 import { ellipsisFn, transformToBaseUnit } from '@polkadot-ui/utils'
 import { rankInfo } from '@/consts'
 
-import type { AccountInfoIF } from './RequestsGrid'
 import copy from 'copy-to-clipboard'
 
 import { api } from '@/clients'
@@ -31,13 +30,14 @@ import {
 } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Link } from 'react-router-dom'
+import type { FellowshipMember } from '@/queries/useFellowshipMembers'
 
 export type LcStatusType = {
   lcStatus: boolean
 }
 
 type MemberInfoProps = {
-  member: AccountInfoIF
+  member: FellowshipMember
   open: boolean
   onOpenChange: Dispatch<SetStateAction<boolean>>
 } & LcStatusType

--- a/src/pages/About/index.tsx
+++ b/src/pages/About/index.tsx
@@ -1,12 +1,15 @@
 import { Button } from '@/components/ui/button'
 import { RequestsGrid } from './RequestsGrid'
 import { openInNewTab } from '@/lib/utils'
+import { useFellowshipMembers } from '@/queries/useFellowshipMembers'
 
 type Props = {
   lcStatus: boolean
 }
 
 export const About = ({ lcStatus }: Props) => {
+  const { data: members } = useFellowshipMembers(lcStatus)
+
   return (
     <main className="grid flex-1 items-start gap-4 p-4 sm:mx-[5%] xl:mx-[15%] mx-0 sm:px-6 sm:py-0 md:gap-8">
       <h1 className="font-unbounded text-primary flex-1 shrink-0 whitespace-nowrap text-xl font-semibold tracking-tight sm:grow-0">
@@ -43,7 +46,7 @@ export const About = ({ lcStatus }: Props) => {
         </Button>
       </div>
       <h1 className="font-unbounded text-primary flex-1 shrink-0 whitespace-nowrap text-xl font-semibold tracking-tight sm:grow-0">
-        Members
+        {`${members?.length || ''} Members`}
       </h1>
       <div className="pageTop">
         List of members and candidates currently inducted in the Fellowship

--- a/src/queries/useFellowshipMembers.ts
+++ b/src/queries/useFellowshipMembers.ts
@@ -1,0 +1,66 @@
+import { api, people_api } from '@/clients'
+import { PeopleQueries } from '@polkadot-api/descriptors'
+import { useQuery } from '@tanstack/react-query'
+import { Binary } from 'polkadot-api'
+
+export type FellowshipMember = {
+  address: string
+  rank: number
+  display?: string
+  github?: string
+  legal?: string
+  matrix?: string
+  email?: string
+  twitter?: string
+  web?: string
+}
+
+const dataToString = (value: number | string | Binary | undefined) =>
+  typeof value === 'object' ? value.asText() : (value ?? '')
+
+const mapRawIdentity = (
+  rawIdentity?: PeopleQueries['Identity']['IdentityOf']['Value'],
+) => {
+  if (!rawIdentity) return rawIdentity
+  const {
+    info: { display, email, legal, matrix, twitter, web },
+  } = rawIdentity[0]
+
+  const display_id = dataToString(display.value)
+
+  return {
+    display: display_id,
+    web: dataToString(web.value),
+    email: dataToString(email.value),
+    legal: dataToString(legal.value),
+    matrix: dataToString(matrix.value),
+    twitter: dataToString(twitter.value),
+  }
+}
+
+export function useFellowshipMembers(lcStatus: boolean) {
+  return useQuery({
+    queryKey: ['fellowship-members'],
+    enabled: api !== null && people_api !== null && lcStatus,
+    staleTime: 2000,
+    queryFn: async () => {
+      const memberEntries =
+        await api?.query.FellowshipCollective.Members.getEntries()
+
+      const identityEntries =
+        await people_api.query.Identity.IdentityOf.getValues(
+          memberEntries.map((m) => m.keyArgs),
+        )
+
+      const members = memberEntries.map((member, idx) => ({
+        address: member.keyArgs[0],
+        rank: member.value,
+        ...mapRawIdentity(identityEntries[idx]),
+      }))
+
+      const sortedMembers = members.sort((a, b) => (a.rank > b.rank ? -1 : 1))
+
+      return sortedMembers as FellowshipMember[]
+    },
+  })
+}


### PR DESCRIPTION
I know it's not everyone's cup of tea, but doing this stuff yourself is cumbersome and prone for failure. It event often let's me skip a state management library completely. At the end of the day it's often just fetching data from a server and displaying it. Mutations are possible as well.

React query keeps track of the loading/pending/idle states for you. Handles errors, offers various callbacks for different outcomes and does reuse results across components through caching via queryKeys. 

Furthermore the implemented coldstart mitigation by retrieving the members by saving/restoring members from localstorage is gracefully handled by a persisting extension to the react-query client. So we get it on all future queries for free.