### PR TITLE
fix: minor typo, due to missing spaces

### DIFF
--- a/src/pages/About/index.tsx
+++ b/src/pages/About/index.tsx
@@ -16,7 +16,7 @@ export const About = ({ lcStatus }: Props) => {
         <p>
           The Polkadot Technical Fellowship is a self-governing body of experts
           and developers of Polkadot and Kusama networks. It operates on-chain
-          through the Polkadot
+          through the Polkadot{' '}
           <a
             target="_blank"
             href={
@@ -24,7 +24,7 @@ export const About = ({ lcStatus }: Props) => {
             }
           >
             Collectives
-          </a>
+          </a>{' '}
           system chain and off-chain through the{' '}
           <a target="_blank" href={'https://github.com/polkadot-fellows'}>
             Polkadot Fellows


### PR DESCRIPTION
Before:
![Screenshot 2024-08-30 at 15 10 05](https://github.com/user-attachments/assets/57d7edde-509e-49a5-a7b8-d777cddd7dc2)

After:
![Screenshot 2024-08-30 at 15 10 00](https://github.com/user-attachments/assets/ad337948-8f27-4ac3-9caa-78c5fcf44e7f)
