### PR TITLE
fix: "Polkadot SDK Mentor issues" link points at a suspended service

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -122,7 +122,7 @@ export const resources: ResourcesType[] = [
       },
       {
         label: 'Polkadot SDK Mentor issues',
-        link: 'https://mentor.tasty.limo/',
+        link: 'https://github.com/paritytech/polkadot-sdk/issues?q=is%3Aopen+label%3AC1-mentor',
         target: '_blank',
       },
       {


### PR DESCRIPTION
## Problem

`src/lib/utils.ts:125` lists a Fellowship onboarding resource labelled **"Polkadot SDK Mentor issues"** pointing at `https://mentor.tasty.limo/`.

That host is gone. It returns **HTTP 503** and the page body is literally:

```
<title>Service Suspended</title>
This service has been suspended by its owner.
```

The link sits in the onboarding resource list, so it is aimed exactly at newcomers looking for a first issue to pick up — the people least likely to work out what went wrong.

## Fix

Point it at the upstream list the service was a front-end for: the `C1-mentor` label on `paritytech/polkadot-sdk`.

```
https://github.com/paritytech/polkadot-sdk/issues?q=is%3Aopen+label%3AC1-mentor
```

## Verification

- old URL: 503 on two separate checks, body confirms the service was suspended by its owner
- new URL: 200 on two separate checks
- the label exists and is populated — `C1-mentor` is described upstream as *"A task where a mentor is available"* and currently has **83 open issues**, so the resource stays genuinely useful

Single line changed; no other resource entries touched.